### PR TITLE
Functional component call instead

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -5,11 +5,7 @@ import styled from 'styled-components';
 const Board = () => {
   return (
     <StyledBoard> 
-      {
-        CharacterNames.map((name) => {
-          return (<div> {name} </div>);
-        })
-      }
+      {CharacterNames.map((name) => <CharacterPanel key={name} name={name} />)}
       <div>
         Player Face
       </div>

--- a/components/CharacterPanel.js
+++ b/components/CharacterPanel.js
@@ -1,7 +1,5 @@
-const CharacterPanel = (name) => {
-  console.log(name)
-  console.log('I\'ve enetered in')
-  return (<div> {name} </div>); 
+const CharacterPanel = (props) => {
+  return <div> {props.name} </div>; 
 }
 
 export default CharacterPanel;


### PR DESCRIPTION
Changing to passing 'props' and using props.name caused it to realize it was a functional component